### PR TITLE
Make upload file component visible

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -488,10 +488,10 @@ body {
 .import-csv {
 	cursor: pointer;
 	position: absolute;
-	opacity: 0;
+	opacity: 1;
 	z-index: 100;
 	left: 0;
-	top: 50px;;
+	top: 60px;;
 }
 
 .btn-import {


### PR DESCRIPTION
The upload component was not visible, setting `opacity` to 1.0
This fixes issue #126 